### PR TITLE
Fix widget Router ambiguity

### DIFF
--- a/lib/components/book.dart
+++ b/lib/components/book.dart
@@ -28,7 +28,7 @@ class BookItem extends StatelessWidget {
   Widget build(BuildContext context) {
     return InkWell(
       onTap: () {
-        Router.pushPage(
+        MyRouter.pushPage(
           context,
           Details(
             entry: entry,

--- a/lib/components/book_card.dart
+++ b/lib/components/book_card.dart
@@ -38,7 +38,7 @@ class BookCard extends StatelessWidget {
             Radius.circular(10.0),
           ),
           onTap: () {
-            Router.pushPage(
+            MyRouter.pushPage(
               context,
               Details(
                 entry: entry,

--- a/lib/components/book_list_item.dart
+++ b/lib/components/book_list_item.dart
@@ -32,7 +32,7 @@ class BookListItem extends StatelessWidget {
   Widget build(BuildContext context) {
     return InkWell(
       onTap: () {
-        Router.pushPage(
+        MyRouter.pushPage(
           context,
           Details(
             entry: entry,

--- a/lib/util/router.dart
+++ b/lib/util/router.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-class Router{
+class MyRouter{
   static Future pushPage(BuildContext context, Widget page) {
     var val = Navigator.push(
       context,

--- a/lib/views/explore/explore.dart
+++ b/lib/views/explore/explore.dart
@@ -83,7 +83,7 @@ class _ExploreState extends State<Explore> {
           ),
           GestureDetector(
             onTap: () {
-              Router.pushPage(
+              MyRouter.pushPage(
                 context,
                 Genre(
                   title: '${link.title}',

--- a/lib/views/home/home.dart
+++ b/lib/views/home/home.dart
@@ -148,7 +148,7 @@ class _HomeState extends State<Home> with AutomaticKeepAliveClientMixin {
                     Radius.circular(20.0),
                   ),
                   onTap: () {
-                    Router.pushPage(
+                    MyRouter.pushPage(
                       context,
                       Genre(
                         title: '${link.title}',

--- a/lib/views/settings/settings.dart
+++ b/lib/views/settings/settings.dart
@@ -112,11 +112,11 @@ class _ProfileState extends State<Profile> {
   }
 
   _pushPage(Widget page) {
-    Router.pushPage(context, page);
+    MyRouter.pushPage(context, page);
   }
 
   _pushPageDialog(Widget page) {
-    Router.pushPageDialog(context, page);
+    MyRouter.pushPageDialog(context, page);
   }
 
   showAbout() {

--- a/lib/views/splash/splash.dart
+++ b/lib/views/splash/splash.dart
@@ -19,7 +19,7 @@ class _SplashState extends State<Splash> {
   }
 
   changeScreen() async {
-    Router.pushPageReplacement(
+    MyRouter.pushPageReplacement(
       context,
       MainScreen(),
     );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.2"
+    version: "2.5.0-nullsafety"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0-nullsafety"
   cached_network_image:
     dependency: "direct main"
     description:
@@ -28,28 +28,28 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety"
+    version: "1.1.0-nullsafety.2"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.3"
+    version: "1.2.0-nullsafety"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.0-nullsafety"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety"
+    version: "1.15.0-nullsafety.2"
   convert:
     dependency: transitive
     description:
@@ -112,7 +112,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.0-nullsafety"
   file:
     dependency: transitive
     description:
@@ -197,14 +197,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.8"
+    version: "0.12.10-nullsafety"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety"
+    version: "1.3.0-nullsafety.2"
   nested:
     dependency: transitive
     description:
@@ -225,7 +225,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0-nullsafety"
   path_provider:
     dependency: "direct main"
     description:
@@ -356,7 +356,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0-nullsafety"
   sqflite:
     dependency: transitive
     description:
@@ -370,21 +370,21 @@ packages:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.5"
+    version: "1.10.0-nullsafety"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0-nullsafety"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "1.1.0-nullsafety"
   synchronized:
     dependency: transitive
     description:
@@ -398,21 +398,21 @@ packages:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0-nullsafety"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.17"
+    version: "0.2.19-nullsafety"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety"
+    version: "1.3.0-nullsafety.2"
   uuid:
     dependency: "direct main"
     description:
@@ -426,7 +426,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety"
+    version: "2.1.0-nullsafety.2"
   xdg_directories:
     dependency: transitive
     description:
@@ -449,5 +449,5 @@ packages:
     source: hosted
     version: "4.3.0"
 sdks:
-  dart: ">=2.9.0-18.0 <2.9.0"
+  dart: ">=2.10.0-0.0.dev <2.10.0"
   flutter: ">=1.17.0 <2.0.0"


### PR DESCRIPTION
This PR fixes the #37 issue:

> With the newest versions of Flutter you are not able to build this project due to the new Router widget they recently introduced. The compiler doesn't know which Widget use to compile (your router widget or the new router widget), it is an ambiguous import.